### PR TITLE
WCOR-0: Update linkit module to beta3 (main)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "drupal/honeypot": "^2.0",
     "drupal/inline_entity_form": "^1.0@RC",
     "drupal/jquery_ui_datepicker": "^1.1",
-    "drupal/linkit": "^6",
+    "drupal/linkit": "^6.0",
     "drupal/masquerade": "^2.0@beta",
     "drupal/masquerade_field": "^1.0@alpha",
     "drupal/masquerade_log": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5cfe525c7f3f36859b657648654f2539",
+    "content-hash": "d5a65affc0c8a93e327dcb15d411b406",
     "packages": [
         {
             "name": "acquia/blt",
@@ -5290,17 +5290,17 @@
         },
         {
             "name": "drupal/linkit",
-            "version": "6.0.0-beta2",
+            "version": "6.0.0-beta3",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/linkit.git",
-                "reference": "6.0.0-beta2"
+                "reference": "6.0.0-beta3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/linkit-6.0.0-beta2.zip",
-                "reference": "6.0.0-beta2",
-                "shasum": "388cd47159eef6c505646c7d5a96e7e653439a94"
+                "url": "https://ftp.drupal.org/files/projects/linkit-6.0.0-beta3.zip",
+                "reference": "6.0.0-beta3",
+                "shasum": "39a5bf54cbc88324d788a573df7b3fecf7622065"
             },
             "require": {
                 "drupal/core": "^8.7.7 || ^9"
@@ -5311,8 +5311,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "6.0.0-beta2",
-                    "datestamp": "1608957496",
+                    "version": "6.0.0-beta3",
+                    "datestamp": "1632933683",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."


### PR DESCRIPTION
### ODE XX

**Use/Fix Case** 

Linkit module needs immediate security update to address cross site scripting vulnerability. 

**Implementation Details**

- Update drupal/linkit to 6.0.0.-beta3

**Dependencies**

- [drupal/linkit](https://www.drupal.org/project/linkit)