### PR TITLE
WCOR-0: Use npm ci instead of npm install.

### DIFF
--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -52,7 +52,7 @@ validate:
 command-hooks:
   frontend-reqs:
     dir: '${docroot}/themes/custom/westy' # directory to your subtheme
-    command: 'npm install'
+    command: 'npm ci'
   frontend-assets:
     dir: '${docroot}/themes/custom/westy' # directory to your subtheme
     command: 'npm run production'


### PR DESCRIPTION
### ODE 214

**Use/Fix Case** 

Issue in pipelines with difference in theme's package-lock.json changing during build.

**Implementation Details**

- Use npm ci in frontend-reqs hook.

**Test Plan**

- [x] Pipelines passes build
