### PR TITLE
WCOR-0: Support for Lando theme building.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ local.blt.yml
 
 # Ignore development configuration files.
 blt.development.services.yml
+xdebug.ini
 
 # Ignore drupal core.
 docroot/core

--- a/.lando.yml
+++ b/.lando.yml
@@ -15,6 +15,37 @@ tooling:
   blt:
     service: appserver
     cmd: /app/vendor/bin/blt
+  npm:
+    description: Run npm commands
+    service: node
+  node:
+    description: Run node commands
+    service: node
+  drush:
+    description: Run drush commands
+    service: appserver
+    cmd: drush --root=/app/docroot
+  xdebug-on:
+    service: appserver
+    description: Enable xdebug for nginx.
+    user: root
+    cmd: docker-php-ext-enable xdebug && pkill -o -USR2 php-fpm && echo "Enabling xdebug"
+  xdebug-off:
+    service: appserver
+    description: Disable xdebug for nginx.
+    user: root
+    cmd: rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && pkill -o -USR2 php-fpm && echo "Disabling xdebug"
+  build-theme:
+    description: Build the production theme; this should match the Acquia BLT build command.
+    service: node
+    cmd: npm -C /app/docroot/themes/custom/westy run production
+  watch-theme:
+    description: Build the production theme; this should match the Acquia BLT build command.
+    service: node
+    cmd: echo "Visit county-drupal-bs.lndo.site once building is complete." && npm -C /app/docroot/themes/custom/westy run watch
+proxy:
+  node:
+    - county-drupal-bs.lndo.site:3000
 services:
   appserver:
     overrides:
@@ -22,9 +53,17 @@ services:
         DRUSH_OPTIONS_URI: "https://county-drupal.lndo.site"
     type: php:8.0
     build_as_root:
-      - mkdir -p /mnt/gfs/wcor.LANDO/nobackup
-      - mkdir -p /mnt/files/wcor.LANDO/sites/default/files-private
-      - chown -R www-data:www-data /mnt/gfs
-      - chown -R www-data:www-data /mnt/files/wcor.LANDO/sites/default
-      - chmod -R g+rw /mnt/gfs
-      - chmod -R g+rw /mnt/files/wcor.LANDO/sites/default
+      - "mkdir -p /mnt/gfs/wcor.LANDO/nobackup"
+      - "mkdir -p /mnt/files/wcor.LANDO/sites/default/files-private"
+      - "chown -R www-data:www-data /mnt/gfs"
+      - "chown -R www-data:www-data /mnt/files/wcor.LANDO/sites/default"
+      - "chmod -R g+rw /mnt/gfs"
+      - "chmod -R g+rw /mnt/files/wcor.LANDO/sites/default"
+      - "cp /app/docroot/themes/custom/westy/config/proxy.lando.js /app/docroot/themes/custom/westy/config/proxy.js"
+  node:
+    type: node:14
+    ssl: true
+    build:
+      - "cd /app/docroot/themes/custom/westy && npm install"
+      - "cd /app/docroot/themes/custom/westy && npm run production"
+    port: 3000

--- a/blt/src/Blt/Plugin/Commands/WashcoCommands.php
+++ b/blt/src/Blt/Plugin/Commands/WashcoCommands.php
@@ -71,10 +71,15 @@ class WashcoCommands extends BltTasks
   {
     $envdir = $this->envsetup();
 
-    $this->say("Installing package dependencies...");
-    shell_exec("npm install --prefix " . $envdir . "/docroot/themes/custom/westy/");
-    $this->say("Building assets...");
-    shell_exec("npm run production --prefix " . $envdir . "/docroot/themes/custom/westy/");
+    if ($_ENV['AH_SITE_ENVIRONMENT'] == "LANDO"){
+      $this->say("Skipping for Lando. Run 'lando build-theme' manually...");
+    }
+    else {
+      $this->say("Installing package dependencies...");
+      shell_exec("npm install --prefix " . $envdir . "/docroot/themes/custom/westy/");
+      $this->say("Building assets...");
+      shell_exec("npm run production --prefix " . $envdir . "/docroot/themes/custom/westy/");
+    }
   }
 
   /**

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,17 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "config": {
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "composer/installers": true,
+      "cweagans/composer-patches": true,
+      "drupal/core-composer-scaffold": true,
+      "wikimedia/composer-merge-plugin": true,
+      "acquia/blt": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "acquia/blt-phpcs": true,
+      "simplesamlphp/composer-module-installer": true
+    }
   },
   "extra": {
     "merge-plugin": {

--- a/composer.lock
+++ b/composer.lock
@@ -5199,24 +5199,12 @@
                     "role": "Maintainer"
                 },
                 {
-                    "name": "davidseth",
-                    "homepage": "https://www.drupal.org/user/254857"
-                },
-                {
-                    "name": "itamair",
-                    "homepage": "https://www.drupal.org/user/1179076"
-                },
-                {
                     "name": "phayes",
                     "homepage": "https://www.drupal.org/user/47098"
                 },
                 {
                     "name": "plopesc",
                     "homepage": "https://www.drupal.org/user/282415"
-                },
-                {
-                    "name": "zzolo",
-                    "homepage": "https://www.drupal.org/user/147331"
                 }
             ],
             "description": "Stores geographic and location data (points, lines, and polygons).",
@@ -12433,6 +12421,7 @@
                 "issues": "https://github.com/tvdijen/simplesamlphp-module-riak/issues",
                 "source": "https://github.com/tvdijen/simplesamlphp-module-riak"
             },
+            "abandoned": true,
             "time": "2019-12-03T08:28:45+00:00"
         },
         {

--- a/docroot/themes/custom/westy/config/proxy.lando.js
+++ b/docroot/themes/custom/westy/config/proxy.lando.js
@@ -1,5 +1,5 @@
-const proxy = 'http://radix.local';
-const domain = '';
+const proxy = 'http://appserver';
+const domain = 'county-drupal-bs.lndo.site';
 const port = 80;
 
 module.exports = {

--- a/docroot/themes/custom/westy/webpack.mix.js
+++ b/docroot/themes/custom/westy/webpack.mix.js
@@ -42,6 +42,11 @@ mix.browserSync({
 	proxy: proxy.proxy,
 	files: ['assets/js/**/*.js', 'assets/css/**/*.css'],
 	stream: true,
+   socket: {
+      domain: proxy.domain,
+      port: proxy.port
+   },
+   open: false
 });
 
 /*


### PR DESCRIPTION
### ODE XX

**Use/Fix Case** 

As a developer, I would like to be able to work on theme development in my local Lando environment.

**Implementation Details**

- [Updated Wiki](https://github.com/Washington-County/COUNTY-DRUPAL/wiki/Lando-local-dev-setup)
- Support for theme watching (browsersync)
- Support for node and npm within lando.
- Support for Composer > 2.2.3

**Test Plan**

- [ ] `lando start` completes successfully.
- [ ] `lando blt custom:catchup` completes successfully.
- [ ] `lando watch-theme` completes successfully. Visiting county-drupal-bs.lndo.site loads successfully after 'watch-theme.'
